### PR TITLE
Upstream 5.2 master 80f23 mcp25xxfd v8.0 fixes

### DIFF
--- a/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can_int.c
+++ b/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can_int.c
@@ -219,9 +219,10 @@ static int mcp25xxfd_can_int_handle_modif(struct mcp25xxfd_can_priv *cpriv)
 
 	/* get the current mode */
 	ret = mcp25xxfd_can_get_mode(cpriv->priv, &mode);
-	if (ret < 0)
+	if (ret)
 		return ret;
-	mode = ret;
+	mode = (mode & MCP25XXFD_CAN_CON_OPMOD_MASK) >>
+		MCP25XXFD_CAN_CON_OPMOD_SHIFT;
 
 	/* switches to the same mode as before are ignored
 	 * - this typically happens if the driver is shortly

--- a/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can_int.c
+++ b/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can_int.c
@@ -219,7 +219,7 @@ static int mcp25xxfd_can_int_handle_modif(struct mcp25xxfd_can_priv *cpriv)
 
 	/* get the current mode */
 	ret = mcp25xxfd_can_get_mode(cpriv->priv, &mode);
-	if (ret)
+	if (ret < 0)
 		return ret;
 	mode = ret;
 


### PR DESCRIPTION
Fix an instance of a mode being used as an error code, then change convention to avoid it happening again by making clear when it's an error and when it's a mode.